### PR TITLE
Automatische Builds

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle
+
+name: Gradle Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+    # the publishing section of your build.gradle
+    - name: Publish to GitHub Packages
+      run: ./gradlew publish
+      env:
+        USERNAME: ${{ github.actor }}
+        TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -29,6 +29,7 @@ jobs:
         run: gradle -PgithubReleaseTag=${{ env.RELEASE_TAG }} buildReleaseArtifacts
       - name: Release
         uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
         with:
           files: |
             release/*.jar

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,6 +1,25 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
+      tags:
+        description: 'Build Release'
+        required: false
+        type: boolean
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: true
   push:
     tags:
       - 'v*'

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -35,6 +35,6 @@ jobs:
           prerelease: false
           title: "Release"
           files: |
-            release/*.jar
+            release/adt/library/*.jar
 
 

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,55 +1,37 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle
-
-name: Gradle Package
+name: Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
-  build:
-
+  release:
+    permissions: write-all
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
+    env:
+      FULL_RELEASE_TAG: ${{ github.ref || format('{0}{1}', 'refs/tags/', github.event.release.tag_name) }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
-
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
-
-    - name: Build with Gradle
-      run: ./gradlew build
-
-    - name: Package into JAR
-      run: |
-         jar cf adt.jar -C out .
-
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v4
-      with:
-         name: adt-jar
-         path: adt.jar
-
-    - name: Create GitHub Release
-      uses: ncipollo/release-action@v1
-      with:
-         artifacts: adt.jar
-         tag: ${{ github.ref_name }}
-         name: Release ${{ github.ref_name }}
-         body: |
-           Automated release for version ${{ github.ref_name }}.
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.5
+      - name: Extract tag name
+        run: |
+          echo "RELEASE_TAG=${FULL_RELEASE_TAG:10}"
+          echo "RELEASE_TAG=${FULL_RELEASE_TAG:10}" >> $GITHUB_ENV
+      - name: Build with Gradle
+        id: build
+        run: gradle -PgithubReleaseTag=${{ env.RELEASE_TAG }} buildReleaseArtifacts
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release/*.jar

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -35,10 +35,21 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
 
-    # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
-    # the publishing section of your build.gradle
-    - name: Publish to GitHub Packages
-      run: ./gradlew publish
-      env:
-        USERNAME: ${{ github.actor }}
-        TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Package into JAR
+      run: |
+         jar cf adt.jar -C out .
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+         name: adt-jar
+         path: adt.jar
+
+    - name: Create GitHub Release
+      uses: ncipollo/release-action@v1
+      with:
+         artifacts: adt.jar
+         tag: ${{ github.ref_name }}
+         name: Release ${{ github.ref_name }}
+         body: |
+           Automated release for version ${{ github.ref_name }}.

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -36,5 +36,6 @@ jobs:
           title: "Release"
           files: |
             release/adt/library/*.jar
+            release/adt.zip
 
 

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,25 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-        type: choice
-        options:
-        - info
-        - warning
-        - debug
-      tags:
-        description: 'Build Release'
-        required: false
-        type: boolean
-      environment:
-        description: 'Environment to run tests against'
-        type: environment
-        required: true
   push:
     tags:
       - 'v*'

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -28,7 +28,7 @@ jobs:
         id: build
         run: gradle -PgithubReleaseTag=${{ env.RELEASE_TAG }} buildReleaseArtifacts
       - name: release
-      - uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: 8.5
       - name: Extract tag name

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,9 +1,6 @@
 name: Release
 
-on:
-  push:
-    tags:
-      - 'v*'
+on: [push]
 
 jobs:
   release:

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -27,9 +27,14 @@ jobs:
       - name: Build with Gradle
         id: build
         run: gradle -PgithubReleaseTag=${{ env.RELEASE_TAG }} buildReleaseArtifacts
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        if: github.ref_type == 'tag'
+      - name: release
+      - uses: "marvinpinto/action-automatic-releases@latest"
         with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: false
+          title: "Release"
           files: |
             release/*.jar
+
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,14 @@ java {
     }
 }
 
+sourceSets {
+    main {
+        java {
+            setSrcDirs(listOf("."))
+        }
+    }
+}
+
 val libraryProperties = Properties().apply {
     load(rootProject.file("release.properties").inputStream())
 }
@@ -74,7 +82,7 @@ tasks.build.get().mustRunAfter("clean")
 tasks.register("buildReleaseArtifacts") {
     group = "processing"
     dependsOn("clean","build", "writeLibraryProperties")
-
+    finalizedBy("packageRelease")
     doFirst {
         println("Releasing library $libName")
         println(org.gradle.internal.jvm.Jvm.current())
@@ -115,4 +123,17 @@ tasks.register("buildReleaseArtifacts") {
             rename("library.properties", "$libName.txt")
         }
     }
+}
+
+
+tasks.register<Zip>("packageRelease") {
+    dependsOn("buildReleaseArtifacts")
+    doFirst {
+        println("Create zip file...")
+    }
+    archiveFileName.set("${libName}.zip")
+    from(releaseDirectory)
+    into(releaseName)
+    destinationDirectory.set(file(releaseRoot))
+    exclude("**/*.DS_Store")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,99 @@
+import java.util.Properties
+import org.gradle.internal.os.OperatingSystem
+
+plugins {
+    id("java")
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+val libraryProperties = Properties().apply {
+    load(rootProject.file("release.properties").inputStream())
+}
+
+version = if (project.hasProperty("githubReleaseTag")) {
+    project.property("githubReleaseTag").toString().drop(1)
+} else {
+    libraryProperties.getProperty("prettyVersion")
+}
+
+val libName = "adt-informatik"
+
+group = "com.Wolfgang"
+repositories {
+    mavenCentral()
+    maven { url = uri("https://jogamp.org/deployment/maven/") }
+}
+
+dependencies {
+    compileOnly(group = "org.processing", name = "core", version = "4.3.1")
+    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+tasks.jar {
+    archiveBaseName.set(libName)
+    archiveClassifier.set("")
+    archiveVersion.set("")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+
+tasks.build.get().mustRunAfter("clean")
+
+tasks.register("buildReleaseArtifacts") {
+    group = "processing"
+    dependsOn("clean","build", "writeLibraryProperties")
+    finalizedBy("packageRelease", "duplicateZipToPdex")
+
+    doFirst {
+        println("Releasing library $libName")
+        println(org.gradle.internal.jvm.Jvm.current())
+
+        println("Cleaning release...")
+        project.delete(files(releaseRoot))
+    }
+
+    doLast {
+        println("Creating package...")
+
+        println("Copy library...")
+        copy {
+            from(layout.buildDirectory.file("libs/${libName}.jar"))
+            into("$releaseDirectory/library")
+        }
+
+        println("Copy dependencies...")
+        copy {
+            from(configurations.runtimeClasspath)
+            into("$releaseDirectory/library")
+        }
+
+        println("Copy additional artifacts...")
+        copy {
+            from(rootDir)
+            include("README.md", "readme/**", "library.properties", "examples/**", "src/**")
+
+            into(releaseDirectory)
+            exclude("*.DS_Store", "**/networks/**")
+        }
+
+        println("Copy repository library.txt...")
+        copy {
+            from(rootDir)
+            include("library.properties")
+            into(releaseRoot)
+            rename("library.properties", "$libName.txt")
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,21 @@ val releaseRoot = "$rootDir/release"
 val releaseName = "adt"
 val releaseDirectory = "$releaseRoot/$releaseName"
 
+tasks.register<WriteProperties>("writeLibraryProperties") {
+    group = "processing"
+    destinationFile = project.file("library.properties")
+
+    property("name", libraryProperties.getProperty("name"))
+    property("version", libraryProperties.getProperty("version"))
+    property("prettyVersion", project.version)
+    property("authors", libraryProperties.getProperty("authors"))
+    property("url", libraryProperties.getProperty("url"))
+    property("categories", libraryProperties.getProperty("categories"))
+    property("sentence", libraryProperties.getProperty("sentence"))
+    property("paragraph", libraryProperties.getProperty("paragraph"))
+    property("minRevision", libraryProperties.getProperty("minRevision"))
+    property("maxRevision", libraryProperties.getProperty("maxRevision"))
+}
 
 tasks.build.get().mustRunAfter("clean")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,6 @@ tasks.build.get().mustRunAfter("clean")
 tasks.register("buildReleaseArtifacts") {
     group = "processing"
     dependsOn("clean","build", "writeLibraryProperties")
-    finalizedBy("packageRelease", "duplicateZipToPdex")
 
     doFirst {
         println("Releasing library $libName")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ version = if (project.hasProperty("githubReleaseTag")) {
     libraryProperties.getProperty("prettyVersion")
 }
 
-val libName = "adt-informatik"
+val libName = "adt"
 
 group = "com.Wolfgang"
 repositories {
@@ -50,7 +50,7 @@ tasks.test {
 
 
 val releaseRoot = "$rootDir/release"
-val releaseName = adt-informatik
+val releaseName = "adt"
 val releaseDirectory = "$releaseRoot/$releaseName"
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,11 @@ tasks.test {
 }
 
 
+val releaseRoot = "$rootDir/release"
+val releaseName = adt-informatik
+val releaseDirectory = "$releaseRoot/$releaseName"
+
+
 tasks.build.get().mustRunAfter("clean")
 
 tasks.register("buildReleaseArtifacts") {

--- a/release.properties
+++ b/release.properties
@@ -1,4 +1,4 @@
-name=Adt Informatik
+name=adt
 version=1
 prettyVersion = 1.0.0
 authors=[Your Name](https://myDomain.com)

--- a/release.properties
+++ b/release.properties
@@ -1,0 +1,10 @@
+name=Adt Informatik
+version=1
+prettyVersion = 1.0.0
+authors=[Your Name](https://myDomain.com)
+url=https://myDomain.com/myLibrary
+categories=Other
+sentence=Wolfgangs abstrakte Datentypen
+paragraph=Wolfgangs abstrakte Datentypen
+minRevision=0
+maxRevision=0


### PR DESCRIPTION
Um das ständige, manuelle compilen und hochladen der Libary zu vereinfachen führt dieser PR automatische Builds via Github Actions ein. 

Sobald an die main branch gepusht wird, wird ein neuer Release mit folgenden Bestandteilen generiert und veröffentlicht:
* der adt.jar Datei
* einem Zip Archiv inklusive library.properties, welche entpackt in den libaries Ordner von Processing verschoben werden kann


